### PR TITLE
Fix attempt of slow cursor when no gamepad is connected

### DIFF
--- a/Emitter/GamepadTracker.cpp
+++ b/Emitter/GamepadTracker.cpp
@@ -42,9 +42,11 @@ bool GamepadTracker::setup() {
     auto count = registeredDevices.size();
     
     if (count == 0) {
-        std::cout << std::format("No game controller found", count) << std::endl;
-        std::cout << std::format("Please ensure it is connected before starting the program", count) << std::endl;
-        return false;
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        SetConsoleTextAttribute(hConsole, FOREGROUND_RED | FOREGROUND_RED | FOREGROUND_INTENSITY);
+        std::cout << std::format("No game controller found !\nPlease ensure it is connected before starting the program.\n", count) << std::endl;
+        SetConsoleTextAttribute(hConsole, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+        return EXIT_FAILURE;
     }
     std::cout << std::format("{} game controller(s) found", count) << std::endl;
 


### PR DESCRIPTION
Note: I'm not a C++ dev. My fix is, without doubt, not the good fix but it works haha

When launching "FsInputEmitter.exe -g", if there is no gamepad to find: the cursor get very slow to control, and it's hard to exit the command window. It happens only in the Mouse + Gamepad case.

I've replaced the "return false" by "return EXIT_FAILURE". I've also changed the text color to red for getting attention to the user of the issue.