### PR TITLE
Version 4.1.1.

### DIFF
--- a/Emitter/DirectInputTracker.h
+++ b/Emitter/DirectInputTracker.h
@@ -14,12 +14,12 @@ private:
     DIJOYSTATE2 st;
     bool _isSetup;
 
-    unsigned int buttonFlags;
+    std::string buttonFlags;
 
     static BOOL CALLBACK onEnumDevice(LPCDIDEVICEINSTANCEW lpddi, LPVOID pvRef);
 public:
 
-    static const unsigned short PROTOCOL_VERSION = 2;
+    static const unsigned short PROTOCOL_VERSION = 3;
 
     std::string state;
     std::string lastError;

--- a/Emitter/GameInputTracker.cpp
+++ b/Emitter/GameInputTracker.cpp
@@ -101,10 +101,10 @@ bool GameInputTracker::refreshState() {
         }
 
         std::stringstream ss;
-        ss << gamepadState.leftThumbstickX
-            << "|" << gamepadState.leftThumbstickY
-            << "|" << gamepadState.rightThumbstickX
-            << "|" << gamepadState.rightThumbstickY
+        ss << gamepadState.leftThumbstickX * 0.5f + 0.5f
+            << "|" << gamepadState.leftThumbstickY * 0.5f + 0.5f
+            << "|" << gamepadState.rightThumbstickX * 0.5f + 0.5f
+            << "|" << gamepadState.rightThumbstickY * 0.5f + 0.5f
             << "|" << gamepadState.leftTrigger
             << "|" << gamepadState.rightTrigger;
         axisCache = ss.str();

--- a/Emitter/Version.h
+++ b/Emitter/Version.h
@@ -2,7 +2,7 @@
 
 #define VERSION_MAJOR 4
 #define VERSION_MINOR 1
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 #define VERSION_BUILD 0
 
 #define STRINGIFY(x) #x


### PR DESCRIPTION
## ⚠️Breaking Changes!

Changed format message of DirectInput mode to be conform to GameInput mode signals.

from semi-colon-separated data
```
{Protocol Version};{Button Flag Decimal Value};{Raw lX};{Raw lY};{Raw lZ};{Raw lRx};{Raw lRy};{Raw lRz};{5-neutral switch numpad-based}
```

to a mix of semi-colon and pipe-separated data
```
{Protocol Version};{Button Flag Binary Value};{switch0}|{switch1}|{switch2}|{switch3};{Normalized lX}|{Normalized lY}|{Normalized lZ}|{Normalized lRx}|{Normalized lRy}|{Normalized lRz}|{Normalized rglSlider0}|{Normalized rglSlider1}
```
where switches and axes are separated by pipes.

The new range for axis changed from 0-65535 to 0.0-1.0.

Moreover, the switch values have been remapped to the following
```
           | Old (Numpad-based) | New (0-neutral)
Neutral    |                  5 |             0
Up         |                  8 |             1
Up-Right   |                  9 |             2
Right      |                  5 |             3
Down-Right |                  3 |             4
Down       |                  2 |             5
Down-Left  |                  1 |             6
Left       |                  4 |             7
Up-Left    |                  7 |             8
```